### PR TITLE
Use `@feature` gates for `timezone`

### DIFF
--- a/wit/monotonic-clock.wit
+++ b/wit/monotonic-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.1-draft;
+package wasi:clocks@0.2.0;
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
 /// time.
 ///

--- a/wit/timezone.wit
+++ b/wit/timezone.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.1-draft;
+package wasi:clocks@0.2.0;
 
 @unstable(feature = clocks-timezone)
 interface timezone {

--- a/wit/timezone.wit
+++ b/wit/timezone.wit
@@ -1,5 +1,6 @@
 package wasi:clocks@0.2.1-draft;
 
+@unstable(feature = clocks-timezone)
 interface timezone {
     use wall-clock.{datetime};
 
@@ -10,15 +11,18 @@ interface timezone {
     /// If the timezone cannot be determined for the given `datetime`, return a
     /// `timezone-display` for `UTC` with a `utc-offset` of 0 and no daylight
     /// saving time.
+    @unstable(feature = clocks-timezone)
     display: func(when: datetime) -> timezone-display;
 
     /// The same as `display`, but only return the UTC offset.
+    @unstable(feature = clocks-timezone)
     utc-offset: func(when: datetime) -> s32;
 
     /// Information useful for displaying the timezone of a specific `datetime`.
     ///
     /// This information may vary within a single `timezone` to reflect daylight
     /// saving time adjustments.
+    @unstable(feature = clocks-timezone)
     record timezone-display {
         /// The number of seconds difference between UTC time and the local
         /// time of the timezone.

--- a/wit/wall-clock.wit
+++ b/wit/wall-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.1-draft;
+package wasi:clocks@0.2.0;
 /// WASI Wall Clock is a clock API intended to let users query the current
 /// time. The name "wall" makes an analogy to a "clock on the wall", which
 /// is not necessarily monotonic as it may be reset.

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.1-draft;
+package wasi:clocks@0.2.0;
 
 world imports {
     import monotonic-clock;


### PR DESCRIPTION
Depends on https://github.com/WebAssembly/WASI/pull/605 to be merged first to reserve a feature gate. This leverages https://github.com/WebAssembly/component-model/pull/332 to add `timezone` as an unstable extension to `wasi:clocks`. From here it can be taken through the various proposal stages and be stabilized in a vote. Thanks!